### PR TITLE
Incomplete implementation for #15

### DIFF
--- a/src/urbit/app/chess.hoon
+++ b/src/urbit/app/chess.hoon
@@ -956,13 +956,10 @@
               %chess-update
               !>([%result game-id.game (need result.updated-game)])
           ==
-          ::  kick subscriber from game
-          :*  %give  %kick  :~  /game/(scot %da game-id.game)/updates
-                                /game/(scot %da game-id.game)/moves
-                            ==
-              ~
-          ==
+          ::
+          ::  XX: filter so i don't get notifs of my own moves
           ?:  in-checkmate
+            ::  checkmate notif works
             :*  =/  title=(list content)
                   ~[[%ship src.bowl] [%text ': checkmate!']]
                 =/  =bin
@@ -986,6 +983,7 @@
                   [%hark-action !>(hark-action)]
                 [%pass /hark-store %agent [our.bowl %hark-store] %poke cage]
             ==
+          ::  resigned notif works
           :*  =/  title=(list content)
                   ~[[%ship src.bowl] [%text ' resigned']]
                 =/  =bin
@@ -997,11 +995,17 @@
                   [%hark-action !>(hark-action)]
                 [%pass /hark-store %agent [our.bowl %hark-store] %poke cage]
             ==
+          ::  kick subscriber from game
+          :*  %give  %kick  :~  /game/(scot %da game-id.game)/updates
+                                /game/(scot %da game-id.game)/moves
+                            ==
+              ~
+          ==
       ==
+  ::
   ::  inform opponent of new position
   ::
   ::  XX: filter so that i don't get notifs of my own moves
-  ::
   :-  `[updated-game u.new-position]
   :~  position-update-card
       :*  =/  title=(list content)

--- a/src/urbit/app/chess.hoon
+++ b/src/urbit/app/chess.hoon
@@ -288,13 +288,6 @@
       :-  :~  :*  %give  %fact  ~[/challenges]
                   %chess-update  !>([%challenge src.bowl challenge])
               ==
-              :*  %pass   /hark-store
-                  %agent  [our.bowl %hark-store]
-                  %poke   :-  %hark-action
-                          !>  :-  %unread-count
-                              :-  [%chess /challenges]
-                              :-  %.y  1
-              ==
               :*  =/  title=(list content)
                     ~[[%ship src.bowl] [%text ' has sent a challenge']]
                   =/  body=(list content)
@@ -314,14 +307,7 @@
           (~(put by challenges-received) src.bowl challenge)
       ==
     %chess-decline-challenge
-      :-  :~  :*  %pass   /hark-store
-                  %agent  [our.bowl %hark-store]
-                  %poke   :-  %hark-action
-                          !>  :-  %unread-count
-                              :-  [%chess /challenges]
-                              :-  %.y  1
-              ==
-              :*  =/  title=(list content)
+      :-  :~  :*  =/  title=(list content)
                     ~[[%ship src.bowl] [%text ' declined your challenge']]
                   =/  =bin
                     [/chess/challenges [%chess /challenges]]
@@ -545,13 +531,6 @@
                     %chess-game  !>(new-game)
                 ==
                 ::  notify us opponent accepted
-                :*  %pass   /hark-store
-                    %agent  [our.bowl %hark-store]
-                    %poke   :-  %hark-action
-                            !>  :-  %unread-count
-                                :-  [%chess /challenges]
-                                :-  %.y  1
-                ==
                 :*  =/  title=(list content)
                       ~[[%ship src.bowl] [%text ' accepts your challenge']]
                     =/  =bin
@@ -692,13 +671,6 @@
                           %chess-update  !>([%draw-offer u.game-id])
                       ==
                       ::  notify hark-store
-                      :*  %pass   /hark-store
-                          %agent  [our.bowl %hark-store]
-                          %poke   :-  %hark-action
-                                  !>  :-  %unread-count
-                                      :-  [%chess /games/(scot %da u.game-id)/updates]
-                                      :-  %.y  1
-                      ==
                       :*  =/  title=(list content)
                             ~[[%ship src.bowl] [%text ' offers a draw']]
                           =/  =bin
@@ -727,13 +699,6 @@
                           ~
                       ==
                       ::  notify hark-store
-                      :*  %pass   /hark-store
-                          %agent  [our.bowl %hark-store]
-                          %poke   :-  %hark-action
-                                  !>  :-  %unread-count
-                                      :-  [%chess /games/(scot %da u.game-id)/updates]
-                                      :-  %.y  1
-                      ==
                       :*  =/  title=(list content)
                             ~[[%ship src.bowl] [%text ' accepts your draw offer']]
                           =/  =bin
@@ -757,13 +722,6 @@
                           %chess-update  !>([%draw-declined u.game-id])
                       ==
                       ::  notify hark-store
-                      :*  %pass   /hark-store
-                          %agent  [our.bowl %hark-store]
-                          %poke   :-  %hark-action
-                                  !>  :-  %unread-count
-                                      :-  [%chess /games/(scot %da u.game-id)/updates]
-                                      :-  %.y  1
-                      ==
                       :*  =/  title=(list content)
                             ~[[%ship src.bowl] [%text ' declines your draw offer']]
                           =/  =bin
@@ -809,14 +767,7 @@
               :-
               %+  welp
                 cards.move-result
-              :~  :*  %pass   /hark-store
-                      %agent  [our.bowl %hark-store]
-                      %poke   :-  %hark-action
-                              !>  :-  %unread-count
-                                  :-  [%chess /games/(scot %da u.game-id)/moves]
-                                  :-  %.y  1
-                  ==
-                  :*  =/  title=(list content)
+              :~  :*  =/  title=(list content)
                         ~[[%ship src.bowl] [%text ' has made a move']]
                       =/  =bin
                         [/chess/updates [%chess /games/(scot %da u.game-id)]]

--- a/src/urbit/app/chess.hoon
+++ b/src/urbit/app/chess.hoon
@@ -857,13 +857,30 @@
               ::  XX: must change %end check after GitHub issue #3 implemented
               ::  XX: notification: opponent resigned
               ?:  ?=(%end -.move)
+                ::  resignation
                 :-  cards.move-result
                 %=  this
                   games    (~(del by games) u.game-id)
                   archive  (~(put by archive) u.game-id game)
                 ==
-              :-
-                cards.move-result
+              :::-  :~  cards.move-result
+              ::        ?:  ::  are we in checkmate?
+              ::          ::  if in checkmate
+              ::        ?:  ::  are we in stalemate?
+              ::          ::  if in stalemate
+              ::        :*  =/  title=(list content)
+              ::              ~[[%ship src.bowl] [%text ' has made a move']]
+              ::            =/  =bin
+              ::              [/chess/updates [%chess /games/(scot %da u.game-id)]]
+              ::            =/  hark-action=action
+              ::              ::  XX: should link to game
+              ::              [%add-note bin title ~ now.bowl / /chess]
+              ::            =/  =cage
+              ::              [%hark-action !>(hark-action)]
+              ::            [%pass /hark-store %agent [our.bowl %hark-store] %poke cage]
+              ::        ==
+              ::    ==
+              :-  cards.move-result
               ::  add new games to our list
               %=  this
                 games  %+  ~(put by games)  u.game-id
@@ -945,9 +962,58 @@
                             ==
               ~
           ==
+          ?:  in-checkmate
+            :*  =/  title=(list content)
+                  ~[[%ship src.bowl] [%text ': checkmate!']]
+                =/  =bin
+                  [/chess/updates [%chess /games/(scot %da game-id.game)]]
+                =/  hark-action=action
+                  ::  XX: should link to game
+                  [%add-note bin title ~ now.bowl / /chess]
+                =/  =cage
+                  [%hark-action !>(hark-action)]
+                [%pass /hark-store %agent [our.bowl %hark-store] %poke cage]
+            ==
+          ?:  in-stalemate
+            :*  =/  title=(list content)
+                  ~[[%ship src.bowl] [%text ' forced a stalemate']]
+                =/  =bin
+                  [/chess/updates [%chess /games/(scot %da game-id.game)]]
+                =/  hark-action=action
+                  ::  XX: should link to game
+                  [%add-note bin title ~ now.bowl / /chess]
+                =/  =cage
+                  [%hark-action !>(hark-action)]
+                [%pass /hark-store %agent [our.bowl %hark-store] %poke cage]
+            ==
+          :*  =/  title=(list content)
+                  ~[[%ship src.bowl] [%text ' resigned']]
+                =/  =bin
+                  [/chess/updates [%chess /games/(scot %da game-id.game)]]
+                =/  hark-action=action
+                  ::  XX: should link to game
+                  [%add-note bin title ~ now.bowl / /chess]
+                =/  =cage
+                  [%hark-action !>(hark-action)]
+                [%pass /hark-store %agent [our.bowl %hark-store] %poke cage]
+            ==
       ==
   ::  inform opponent of new position
+  ::
+  ::  XX: filter so that i don't get notifs of my own moves
+  ::
   :-  `[updated-game u.new-position]
   :~  position-update-card
+      :*  =/  title=(list content)
+            ~[[%ship src.bowl] [%text ' has made a move']]
+          =/  =bin
+            [/chess/updates [%chess /games/(scot %da game-id.game)]]
+          =/  hark-action=action
+            ::  XX: should link to game
+            [%add-note bin title ~ now.bowl / /chess]
+          =/  =cage
+            [%hark-action !>(hark-action)]
+          [%pass /hark-store %agent [our.bowl %hark-store] %poke cage]
+      ==
   ==
 --

--- a/src/urbit/app/chess.hoon
+++ b/src/urbit/app/chess.hoon
@@ -1,4 +1,4 @@
-/+  chess, dbug, default-agent
+/+  chess, dbug, default-agent, hark=hark-store
 =,  chess
 |%
 +$  versioned-state
@@ -273,13 +273,52 @@
       :-  :~  :*  %give  %fact  ~[/challenges]
                   %chess-update  !>([%challenge src.bowl challenge])
               ==
+              :*  %pass   /hark-store
+                  %agent  [our.bowl %hark-store]
+                  %poke   :-  %hark-action
+                          !>  :-  %unread-count
+                              :-  %chess
+                              :-  /challenges
+                              :-  %.y  1
+              ==
+              :*  =/  title=(list content:hark)
+                    ~[[%text (crip "{<src.bowl>} has sent a challenge")]]
+                  =/  body=(list content:hark)
+                    ~[[%text event.challenge]]
+                  =/  =bin:hark
+                    [/chess [%chess /challenges]]
+                  =/  hark-action=action:hark
+                    ::  XX: should link to game
+                    [%add-note bin title body now.bowl / /chess]
+                  =/  =cage
+                    [%hark-action !>(hark-action)]
+                  [%pass /hark-store %agent [our.bowl %hark-store] %poke cage]
+              ==
           ==
       %=  this
         challenges-received
           (~(put by challenges-received) src.bowl challenge)
       ==
     %chess-decline-challenge
-      :-  ~
+      :-  :~  :*  %pass   /hark-store
+                  %agent  [our.bowl %hark-store]
+                  %poke   :-  %hark-action
+                          !>  :-  %unread-count
+                              :-  %chess
+                              :-  /challenges
+                              :-  %.y  1
+              ==
+              :*  =/  title=(list content:hark)
+                    ~[[%text (crip "{<src.bowl>} declined your challenge")]]
+                  =/  =bin:hark
+                    [/chess [%chess /challenges]]
+                  =/  hark-action=action:hark
+                    [%add-note bin title ~ now.bowl / /chess]
+                  =/  =cage
+                    [%hark-action !>(hark-action)]
+                  [%pass /hark-store %agent [our.bowl %hark-store] %poke cage]
+              ==
+          ==
       %=  this
         challenges-sent  (~(del by challenges-sent) src.bowl)
       ==
@@ -592,11 +631,41 @@
           ?~  p.sign
             [~ this]
           %-  (slog u.p.sign)
-          :-  ~
+          :-
+            ::  XX: frontend popup: ~sampel-palnet doesn't have %chess!
+            ~
           %=  this
             challenges-sent  (~(del by challenges-sent) src.bowl)
           ==
       ==
+    ::[%active-games ~]
+    ::?+  -.sign  (on-agent:default wire sign)
+    ::  %fact
+    ::    ?+  p.cage.sign  (on-agent:default wire sign)
+    ::      %chess-game
+    ::        :_  this
+    ::        :~  ::  notify us opponent accepted
+    ::            :*  %pass   /hark-store
+    ::                %agent  [our.bowl %hark-store]
+    ::                %poke   :-  %hark-action
+    ::                        !>  :-  %unread-count
+    ::                            :-  %chess
+    ::                            :-  /challenges
+    ::                            :-  %.y  1
+    ::            ==
+    ::            :*  =/  title=(list content:hark)
+    ::                  ~[[%text (crip "{<src.bowl>} accepts your challenge")]]
+    ::                =/  =bin:hark
+    ::                  [/chess [%chess /challenges]]
+    ::                =/  hark-action=action:hark
+    ::                  ::  XX: should link to game
+    ::                  [%add-note bin title ~ now.bowl / /chess]
+    ::                =/  =cage
+    ::                  [%hark-action !>(hark-action)]
+    ::                [%pass /hark-store %agent [our.bowl %hark-store] %poke cage]
+    ::            ==
+    ::        ==
+    ::    ==
     [%player @ta ~]
       =/  game-id  `(unit @dau)`(slaw %da i.t.wire)
       ?~  game-id
@@ -614,9 +683,52 @@
       ?+  -.sign  (on-agent:default wire sign)
         %fact
           ?+  p.cage.sign  (on-agent:default wire sign)
+             %chess-game
+              :_  this
+              :~  ::  notify us opponent accepted
+                  :*  %pass   /hark-store
+                      %agent  [our.bowl %hark-store]
+                      %poke   :-  %hark-action
+                              !>  :-  %unread-count
+                                  :-  %chess
+                                  :-  /challenges
+                                  :-  %.y  1
+                  ==
+                  :*  =/  title=(list content:hark)
+                        ~[[%text (crip "{<src.bowl>} accepts your challenge")]]
+                      =/  =bin:hark
+                        [/chess [%chess /challenges]]
+                      =/  hark-action=action:hark
+                        ::  XX: should link to game
+                        [%add-note bin title ~ now.bowl / /chess]
+                      =/  =cage
+                        [%hark-action !>(hark-action)]
+                      [%pass /hark-store %agent [our.bowl %hark-store] %poke cage]
+                  ==
+              ==
             %chess-draw-offer
               :-  :~  :*  %give  %fact  ~[/game/(scot %da u.game-id)/updates]
                           %chess-update  !>([%draw-offer u.game-id])
+                      ==
+                      ::  notify hark-store
+                      :*  %pass   /hark-store
+                          %agent  [our.bowl %hark-store]
+                          %poke   :-  %hark-action
+                                  !>  :-  %unread-count
+                                      :-  %chess
+                                      :-  /games/(scot %da u.game-id)/updates
+                                      :-  %.y  1
+                      ==
+                      :*  =/  title=(list content:hark)
+                            ~[[%text (crip "{<src.bowl>} offers a draw")]]
+                          =/  =bin:hark
+                            [/chess/games [%chess /games/(scot %da u.game-id)/updates]]
+                          =/  hark-action=action:hark
+                            ::  XX: should link to game
+                            [%add-note bin title ~ now.bowl / /chess]
+                          =/  =cage
+                            [%hark-action !>(hark-action)]
+                          [%pass /hark-store %agent [our.bowl %hark-store] %poke cage]
                       ==
                   ==
               %=  this
@@ -634,6 +746,26 @@
                                         ==
                           ~
                       ==
+                      ::  notify hark-store
+                      :*  %pass   /hark-store
+                          %agent  [our.bowl %hark-store]
+                          %poke   :-  %hark-action
+                                  !>  :-  %unread-count
+                                      :-  %chess
+                                      :-  /games/(scot %da u.game-id)/updates
+                                      :-  %.y  1
+                      ==
+                      :*  =/  title=(list content:hark)
+                            ~[[%text (crip "{<src.bowl>} accepts your draw offer")]]
+                          =/  =bin:hark
+                            [/chess/games [%chess /games/(scot %da u.game-id)/updates]]
+                          =/  hark-action=action:hark
+                            ::  XX: should link to game
+                            [%add-note bin title ~ now.bowl / /chess]
+                          =/  =cage
+                            [%hark-action !>(hark-action)]
+                          [%pass /hark-store %agent [our.bowl %hark-store] %poke cage]
+                      ==
                   ==
               =/  updated-game  game.u.game-state
               =.  result.updated-game  `%'½–½'
@@ -644,6 +776,26 @@
             %chess-draw-decline
               :-  :~  :*  %give  %fact  ~[/game/(scot %da u.game-id)/updates]
                           %chess-update  !>([%draw-declined u.game-id])
+                      ==
+                      ::  notify hark-store
+                      :*  %pass   /hark-store
+                          %agent  [our.bowl %hark-store]
+                          %poke   :-  %hark-action
+                                  !>  :-  %unread-count
+                                      :-  %chess
+                                      :-  /games/(scot %da u.game-id)/updates
+                                      :-  %.y  1
+                      ==
+                      :*  =/  title=(list content:hark)
+                            ~[[%text (crip "{<src.bowl>} declines your draw offer")]]
+                          =/  =bin:hark
+                            [/chess/games [%chess /games/(scot %da u.game-id)/updates]]
+                          =/  hark-action=action:hark
+                            ::  XX: should link to game
+                            [%add-note bin title ~ now.bowl / /chess]
+                          =/  =cage
+                            [%hark-action !>(hark-action)]
+                          [%pass /hark-store %agent [our.bowl %hark-store] %poke cage]
                       ==
                   ==
               %=  this
@@ -658,12 +810,47 @@
               ?~  new.move-result
                 [cards.move-result this]  ::  nice try, cheater
               =,  u.new.move-result
-              :-  cards.move-result
-              ?.  ?=(~ result.game)
+              ::
+              ::  XX: shouldn't notify if %chess is open
+              ::  XX: post-Groups 2, should create more granular
+              ::      notifications about moves:
+              ::      '~sampel-palnet moves E5 pawn to E6'
+              ::      '~sampel-palnet: check!'
+              ::      '~sampel-palnet: checkmate!'
+              ::      '~sampel-palnet promotes XX pawn to queen'
+              ::
+              ::  check if opponent has resigned
+              ::  XX: must change %end check after GitHub issue #3 implemented
+              ::  XX: notification: opponent resigned
+              ?:  ?=(%end -.move)
+                :-  cards.move-result
                 %=  this
                   games    (~(del by games) u.game-id)
                   archive  (~(put by archive) u.game-id game)
                 ==
+              :-
+              %+  welp
+                cards.move-result
+              :~  :*  %pass   /hark-store
+                      %agent  [our.bowl %hark-store]
+                      %poke   :-  %hark-action
+                              !>  :-  %unread-count
+                                  :-  %chess
+                                  :-  /games/(scot %da u.game-id)/moves
+                                  :-  %.y  1
+                  ==
+                  :*  =/  title=(list content:hark)
+                        ~[[%text (crip "{<src.bowl>} has made a move")]]
+                      =/  =bin:hark
+                        [/chess/games [%chess /games/(scot %da u.game-id)/updates]]
+                      =/  hark-action=action:hark
+                        ::  XX: should link to game
+                        [%add-note bin title ~ now.bowl / /chess]
+                      =/  =cage
+                        [%hark-action !>(hark-action)]
+                      [%pass /hark-store %agent [our.bowl %hark-store] %poke cage]
+                  ==
+              ==
               %=  this
                 games  %+  ~(put by games)  u.game-id
                        [game position |2.u.game-state]


### PR DESCRIPTION
Missing notifications for "opponent accepted your challenge" and "opponent resigned". I've tried putting the acceptance notification everywhere I could think to, but the notification never fires. I know where the resgination notif. should go and that's labelled with an `XX: notification:`, but I can't think why it wouldn't fire.

Other than their placement in the file, the only notable thing about these notifications is the `path` in `hark-store` they're sent to. Most notifications are sent to `/challenges`, `/games/<game-id>/moves`, or `/games/<game-id>/updates`, but to avoid referring to games that don't exist the acceptance notif. is sent to `/challenges` and the resignation is sent to `/games`. I don't think this should matter as those locations are created by referencing them in the `hark-store` poke, so maybe I'm trying to fire them in the wrong place.

I'm aware `hark-store` is being deprecated, so I've left comments sketching more granular notifications for moves, checks, and checkmates, but I think that'll require some work across the codebase that's not worth doing if `hark-store` is going to be out of date in a couple of months. Maybe there should be a 'checkmate!' notification, but as mentioned in the comments around line 900 how we solve issue #3 might interfere with that logic.