### PR TITLE
Add scry path and wire for outgoing challenges

### DIFF
--- a/src/frontend/ts/state/chessState.ts
+++ b/src/frontend/ts/state/chessState.ts
@@ -2,20 +2,20 @@ import Urbit from '@urbit/http-api'
 import { Ship, GameID, GameInfo, ActiveGameInfo, Challenge, ChessUpdate, ChallengeUpdate } from '../types/urbitChess'
 
 interface ChessState {
-  urbit: Urbit | null;
-  displayGame: ActiveGameInfo | null;
-  practiceBoard: String | null;
-  activeGames: Map<GameID, ActiveGameInfo>;
-  incomingChallenges: Map<Ship, Challenge>;
-  setUrbit: (urbit: Urbit) => void;
-  setDisplayGame: (displayGame: ActiveGameInfo | null) => void;
-  setPracticeBoard: (practiceBoard: String | null) => void;
-  receiveChallenge: (data: ChallengeUpdate) => void;
-  receiveGame: (data: GameInfo) => void;
-  receiveUpdate: (data: ChessUpdate) => void;
-  removeChallenge: (who: Ship) => void;
-  declinedDraw: (gameID: GameID) => void;
-  offeredDraw: (gameID: GameID) => void;
+  urbit: Urbit | null
+  displayGame: ActiveGameInfo | null
+  practiceBoard: String | null
+  activeGames: Map<GameID, ActiveGameInfo>
+  incomingChallenges: Map<Ship, Challenge>
+  outgoingChallenges: Map<Ship, Challenge>
+  setUrbit: (urbit: Urbit) => void
+  setDisplayGame: (displayGame: ActiveGameInfo | null) => void
+  setPracticeBoard: (practiceBoard: String | null) => void
+  receiveChallengeUpdate: (data: ChallengeUpdate) => void
+  receiveGame: (data: GameInfo) => void
+  receiveUpdate: (data: ChessUpdate) => void
+  declinedDraw: (gameID: GameID) => void
+  offeredDraw: (gameID: GameID) => void
 }
 
 export default ChessState

--- a/src/frontend/ts/types/urbitChess.ts
+++ b/src/frontend/ts/types/urbitChess.ts
@@ -28,7 +28,10 @@ export enum Result {
 }
 
 export enum Update {
-  Challenge = 'challenge',
+  ChallengeSent = 'challenge-sent',
+  ChallengeReceived = 'challenge-received',
+  ChallengeResolved = 'challenge-resolved',
+  ChallengeReplied = 'challenge-replied',
   Position = 'position',
   Result = 'result',
   DrawOffer = 'draw-offer',
@@ -104,8 +107,22 @@ export interface ChessUpdate {
 }
 
 export interface ChallengeUpdate extends ChessUpdate {
-  chessUpdate: Update.Challenge
+  chessUpdate: Update.ChallengeSent |
+               Update.ChallengeReceived |
+               Update.ChallengeResolved |
+               Update.ChallengeReplied
   who: Ship
+}
+
+export interface ChallengeSentUpdate extends ChallengeUpdate {
+  chessUpdate: Update.ChallengeSent
+  challengerSide: Side
+  event: string
+  round: string
+}
+
+export interface ChallengeReceivedUpdate extends ChallengeUpdate {
+  chessUpdate: Update.ChallengeReceived
   challengerSide: Side
   event: string
   round: string

--- a/src/frontend/tsx/App.tsx
+++ b/src/frontend/tsx/App.tsx
@@ -8,7 +8,7 @@ import { Menu } from './Menu'
 import { GamePanel } from './GamePanel'
 
 export function App () {
-  const { urbit, setUrbit, receiveChallenge, receiveGame } = useChessStore()
+  const { urbit, setUrbit, receiveChallengeUpdate, receiveGame } = useChessStore()
 
   //
   // Helper functions
@@ -18,12 +18,11 @@ export function App () {
     const newUrbit = new Urbit('', '')
     newUrbit.ship = window.ship
     setUrbit(newUrbit)
-
     await newUrbit.subscribe({
       app: 'chess',
       path: '/challenges',
       err: () => {},
-      event: (data: ChallengeUpdate) => receiveChallenge(data),
+      event: (data: ChallengeUpdate) => receiveChallengeUpdate(data),
       quit: () => {}
     })
     await newUrbit.subscribe({

--- a/src/frontend/tsx/Challenges.tsx
+++ b/src/frontend/tsx/Challenges.tsx
@@ -15,8 +15,10 @@ export function Challenges () {
   const [friends, setFriends] = useState([])
   const [challengingFriend, setChallengingFriend] = useState(false)
   const [showingFriends, setFriendsList] = useState(false)
+  const [showingIncoming, setIncoming] = useState(true)
+  const [showingOutgoing, setOutgoing] = useState(false)
   const [badChallengeAttempts, setBadChallengeAttempts] = useState(0)
-  const { urbit, incomingChallenges, removeChallenge } = useChessStore()
+  const { urbit, incomingChallenges, outgoingChallenges } = useChessStore()
 
   const openModal = () => {
     setModalOpen(true)
@@ -54,19 +56,11 @@ export function Challenges () {
   }
 
   const acceptChallenge = async (who: Ship) => {
-    const onSuccess = () => {
-      removeChallenge(who)
-    }
-
-    await pokeAction(urbit, acceptGame(who), () => {}, onSuccess)
+    await pokeAction(urbit, acceptGame(who), () => {})
   }
 
   const declineChallenge = async (who: Ship) => {
-    const onSuccess = () => {
-      removeChallenge(who)
-    }
-
-    await pokeAction(urbit, declineGame(who), () => {}, onSuccess)
+    await pokeAction(urbit, declineGame(who), () => {})
   }
 
   const sendChallenge = async () => {
@@ -87,16 +81,27 @@ export function Challenges () {
     // XX: set showingIncoming and showingOutgoing to false
   }
 
+  const openIncoming = () => {
+    setIncoming(true)
+    setOutgoing(false)
+  }
+
+  const openOutgoing = () => {
+    setOutgoing(true)
+    setIncoming(false)
+  }
+
   return (
     <div className='challenges-container col'>
       <div id="challenges-header" className="control-panel-container col">
         <button className='option' onClick={openModal}>New Challenge</button>
         {/* XX: see how it looks replacing • with ☙ or ❧ or ❦ or 𐫱 */}
         <p>
-          <span>Incoming</span> ☙ <span>Outgoing</span> ❧ <span onClick={openFriends}>Friends</span>
+          <span onClick={openIncoming}>Incoming</span> ☙ <span onClick={openOutgoing}>Outgoing</span> ❧ <span onClick={openFriends}>Friends</span>
         </p>
       </div>
-      <ul id="incoming-challenges" className='game-list'>
+      {/* incoming challenges list */}
+      <ul id="incoming-challenges" className='game-list' style={{ display: (showingIncoming ? 'flex' : ' none') }}>
         {
           Array.from(incomingChallenges).map(([challenger, challenge], key) => {
             const colorClass = (key % 2) ? 'odd' : 'even'
@@ -129,8 +134,35 @@ export function Challenges () {
           })
         }
       </ul>
-      <ul id="outgoing-challenges" className='game-list'>
-        {/* return outgoing list */}
+      {/* outgoing challenges list */}
+      <ul id="outgoing-challenges" className='game-list' style={{ display: (showingOutgoing ? 'flex' : ' none') }}>
+        {
+          Array.from(outgoingChallenges).map(([challenged, challenge], key) => {
+            const colorClass = (key % 2) ? 'odd' : 'even'
+            const description = challenge.event
+            const mySide = (challenge.challengerSide === Side.White) ? 'w' : 'b'
+            return (
+              <li className={`game challenge ${colorClass}`} key={key}>
+                <div className='challenge-box'>
+                  <div className='row'>
+                    <img
+                      src={`https://raw.githubusercontent.com/lichess-org/lila/5a9672eacb870d4d012ae09d95aa4a7fdd5c8dbf/public/piece/cburnett/${mySide}N.svg`}
+                    />
+                    <div className='col'>
+                      <p className='challenger-name'>{challenged}</p>
+                      <p
+                        title={description}
+                        className='challenger-desc'
+                      >
+                        {description}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            )
+          })
+        }
       </ul>
       <ul id="friends" className='game-list' style={{ display: (showingFriends ? 'flex' : ' none') }}>
         {
@@ -147,7 +179,7 @@ export function Challenges () {
                     </div>
                   </div>
                   <div className='col'>
-                    <button className='quick-game' onClick={() => { setChallengingFriend(true); setWho('~' + friend); openModal(); }}>Challenge</button>
+                    <button className='quick-game' onClick={() => { setChallengingFriend(true); setWho('~' + friend); openModal() }}>Challenge</button>
                   </div>
                 </div>
               </li>

--- a/src/urbit/mar/chess/challenges.hoon
+++ b/src/urbit/mar/chess/challenges.hoon
@@ -1,0 +1,13 @@
+/+  chess
+=,  chess
+|_  challenge=(list [@p chess-challenge])
+++  grab
+  |%
+  ++  noun  (list [@p chess-challenge])
+  --
+++  grow
+  |%
+  ++  noun  challenge
+  --
+++  grad  %noun
+--

--- a/src/urbit/mar/chess/update.hoon
+++ b/src/urbit/mar/chess/update.hoon
@@ -9,14 +9,37 @@
   |%
   ++  noun  upd
   ++  json
+    ::  XX: split %chess-update and /updates into several marks/wires
+    ::
+    ::      we shouldn't have all this information in one wire.
+    ::      as the chess app grows this will become unwieldy,
+    ::      subscribers to a wire only want the relevant info.
     ?-  -.upd
-      %challenge
+      %challenge-sent
         %-  pairs:enjs
-        :~  ['chessUpdate' [%s 'challenge']]
+        :~  ['chessUpdate' [%s 'challenge-sent']]
             ['who' [%s (scot %p who.upd)]]
             ['challengerSide' [%s challenger-side.challenge.upd]]
             ['event' [%s event.challenge.upd]]
             ['round' [%s (round-string:chess round.challenge.upd)]]
+        ==
+      %challenge-received
+        %-  pairs:enjs
+        :~  ['chessUpdate' [%s 'challenge-received']]
+            ['who' [%s (scot %p who.upd)]]
+            ['challengerSide' [%s challenger-side.challenge.upd]]
+            ['event' [%s event.challenge.upd]]
+            ['round' [%s (round-string:chess round.challenge.upd)]]
+        ==
+      %challenge-resolved
+        %-  pairs:enjs
+        :~  ['chessUpdate' [%s 'challenge-resolved']]
+            ['who' [%s (scot %p who.upd)]]
+        ==
+      %challenge-replied
+        %-  pairs:enjs
+        :~  ['chessUpdate' [%s 'challenge-replied']]
+            ['who' [%s (scot %p who.upd)]]
         ==
       %position
         %-  pairs:enjs

--- a/src/urbit/sur/chess.hoon
+++ b/src/urbit/sur/chess.hoon
@@ -242,11 +242,14 @@
 ::  chess-update defines the possible values that a
 ::  subscriber may receive as a %fact from the chess agent
 +$  chess-update
-  $%  [%challenge who=ship challenge=chess-challenge]
+  $%  [%challenge-sent who=ship challenge=chess-challenge]
+      [%challenge-received who=ship challenge=chess-challenge]
+      [%challenge-resolved who=ship]
+      [%challenge-replied who=ship]
       [%position game-id=@dau position=@t special-draw-available=?]
-      [%result game-id=@dau result=chess-result]
       [%draw-offer game-id=@dau]
       [%draw-declined game-id=@dau]
+      [%result game-id=@dau result=chess-result]
       [%special-draw-preference game-id=@dau setting=?]
   ==
 ::


### PR DESCRIPTION
Partially addresses #7.

As with the `%pals` integration, this code looks correct to me but I can't test that because I don't understand how the two marks in a scry interact.

Scry `.^(json %gx /=chess=/outgoing/json)` gets an error with `peek no tube from chess-outgoing to json`, if that's of use.