### PR TITLE
Add support for TypeScript -w compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build
 lila
 node_modules
+tsc-watch

--- a/src/frontend/tsconfig.json
+++ b/src/frontend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "outDir": "./dist/",
+    "outDir": "./tsc-watch",
     "noImplicitAny": true,
     "module": "ES2020",
     "target": "ES2021",


### PR DESCRIPTION
TypeScript's `tsc -w` command catches compile-time errors in your TypeScript files as soon as you save the file. This commit adds an "outDir" option for `tsconfig.json`, enabling a `tsc -w` compile.

This compile doesn't create a glob-ready `/build/frontend` folder. To enable that, we'd need another config file and maybe even another npm package. The `/build` folder should be cleared at the start of every compile before a new glob.

As is, the `tsc -w` compile is only for catching errors in your `.ts` and `.tsx` files as soon as you make them, rather than waiting for a "real" compile attempt to finish.