### PR TITLE
Add game panel functionality

### DIFF
--- a/src/frontend/css/general.css
+++ b/src/frontend/css/general.css
@@ -114,11 +114,8 @@ div.game-panel .moves {
   border: 1px black solid;
 }
 
-div.game-panel .moves-divider {
-  min-height: 275px;
-  width: 1.45em;
-  position: absolute;
-  border-right: 1px black solid;
+div.game-panel .move-item span {
+  cursor: pointer;
 }
 
 div.game-panel .moves p {
@@ -156,15 +153,6 @@ div.game-container {
   align-items: center;
   justify-items: center;
   justify-content: center;
-}
-
-div.title-container {
-  grid-area: top;
-  height: calc(max(10vh, 72px) - max(min(2vh, 2vw), 14px));
-  width: calc(max(75vw, 960px) - calc(2 * max(min(2vh, 2vw), 14px)));
-  display: grid;
-  align-items: center;
-  justify-items: center;
 }
 
 div.turn-container {

--- a/src/frontend/css/text.css
+++ b/src/frontend/css/text.css
@@ -33,3 +33,8 @@
   font-size: 2em;
   font-weight: bold;
 }
+
+/* game panel list */
+.moves ol {
+  list-style-type: decimal-leading-zero;
+}

--- a/src/frontend/ts/state/chessState.ts
+++ b/src/frontend/ts/state/chessState.ts
@@ -1,16 +1,20 @@
 import Urbit from '@urbit/http-api'
-import { Ship, GameID, GameInfo, ActiveGameInfo, Challenge, ChessUpdate, ChallengeUpdate } from '../types/urbitChess'
+import { Ship, GameID, SAN, FENPosition, Move, GameInfo, ActiveGameInfo, Challenge, ChessUpdate, ChallengeUpdate } from '../types/urbitChess'
 
 interface ChessState {
+  // properties
   urbit: Urbit | null
   displayGame: ActiveGameInfo | null
+  displayIndex: number | null
   practiceBoard: String | null
   activeGames: Map<GameID, ActiveGameInfo>
   incomingChallenges: Map<Ship, Challenge>
   outgoingChallenges: Map<Ship, Challenge>
   friends: Array<Ship>
+  // functions
   setUrbit: (urbit: Urbit) => void
   setDisplayGame: (displayGame: ActiveGameInfo | null) => void
+  setDisplayIndex: (displayIndex: number | null) => void
   setPracticeBoard: (practiceBoard: String | null) => void
   setFriends: (friends: Array<Ship>) => void
   receiveChallengeUpdate: (data: ChallengeUpdate) => void

--- a/src/frontend/ts/types/urbitChess.ts
+++ b/src/frontend/ts/types/urbitChess.ts
@@ -69,7 +69,14 @@ export type Ship = string
 
 export type GameID = string
 
+export type SAN = string
+
 export type FENPosition = string
+
+export type Move = {
+  san: SAN
+  fen: FENPosition
+}
 
 export type GameInfo = {
   gameID: GameID,
@@ -78,7 +85,8 @@ export type GameInfo = {
   round: string,
   white: Ship,
   black: Ship,
-  result: Result
+  result: Result,
+  moves: Array<Move>
 }
 
 export type ActiveGameInfo = {
@@ -133,6 +141,7 @@ export interface PositionUpdate extends ChessUpdate {
   gameID: GameID
   position: FENPosition
   specialDrawAvailable: boolean
+  move: Move | null
 }
 
 export interface ResultUpdate extends ChessUpdate {

--- a/src/frontend/tsx/App.tsx
+++ b/src/frontend/tsx/App.tsx
@@ -7,9 +7,10 @@ import { findFriends } from '../ts/helpers/urbitChess'
 import { Chessboard } from './Chessboard'
 import { Menu } from './Menu'
 import { GamePanel } from './GamePanel'
+import { PracticePanel } from './PracticePanel'
 
 export function App () {
-  const { urbit, setUrbit, receiveChallengeUpdate, receiveGame, setFriends } = useChessStore()
+  const { urbit, setUrbit, receiveChallengeUpdate, receiveGame, displayGame, setFriends } = useChessStore()
 
   //
   // Helper functions
@@ -56,7 +57,11 @@ export function App () {
   return (
     <Beforeunload onBeforeunload={teardown}>
       <div className='app-container'>
-        <GamePanel />
+        {
+          (displayGame == null)
+            ? <PracticePanel />
+            : <GamePanel />
+        }
         <Chessboard />
         <Menu />
       </div>

--- a/src/frontend/tsx/GamePanel.tsx
+++ b/src/frontend/tsx/GamePanel.tsx
@@ -1,13 +1,17 @@
-import React from 'react'
+import React, { useState } from 'react'
+import { Chess, ChessInstance } from 'chess.js'
 import useChessStore from '../ts/state/chessStore'
 import { pokeAction, resign, offerDraw, claimSpecialDraw } from '../ts/helpers/urbitChess'
-import { Side, GameID, GameInfo, ActiveGameInfo } from '../ts/types/urbitChess'
 import { CHESS } from '../ts/constants/chess'
+import { Side, GameID, SAN, GameInfo, ActiveGameInfo } from '../ts/types/urbitChess'
 
 export function GamePanel () {
-  const { urbit, displayGame, setDisplayGame, offeredDraw, practiceBoard, setPracticeBoard } = useChessStore()
+  const { urbit, displayGame, setDisplayGame, offeredDraw, practiceBoard, setPracticeBoard, displayIndex, setDisplayIndex } = useChessStore()
   const hasGame: boolean = (displayGame !== null)
   const practiceHasMoved = (localStorage.getItem('practiceBoard') !== CHESS.defaultFEN)
+  const opponent = !hasGame ? '~sampel-palnet' : (urbit.ship === displayGame.info.white.substring(1))
+    ? displayGame.info.black
+    : displayGame.info.white
 
   const resignOnClick = async () => {
     const gameID = displayGame.info.gameID
@@ -24,46 +28,67 @@ export function GamePanel () {
     await pokeAction(urbit, claimSpecialDraw(gameID))
   }
 
+  const moveOpacity = (index: number) => {
+    if (displayIndex == null || index <= displayIndex) {
+      return 1.0
+    } else {
+      return 0.3
+    }
+  }
+
+  const moveList = () => {
+    let displayMoves = (displayGame.info.moves !== null) ? displayGame.info.moves : []
+    let components = []
+    for (let wIndex: number = 0; wIndex < displayMoves.length; wIndex += 2) {
+      const move: number = (wIndex / 2) + 1
+      const bIndex: number = wIndex + 1
+      const wMove: SAN = displayMoves[wIndex].san
+
+      if (bIndex >= displayMoves.length) {
+        components.push(
+          <li key={ move } className='move-item' style={{ opacity: moveOpacity(wIndex) }}>
+            <span onClick={ () => setDisplayIndex(wIndex) }>
+              { wMove }
+            </span>
+          </li>
+        )
+      } else {
+        components.push(
+          <li key={ move } className='move-item' style={{ opacity: moveOpacity(wIndex) }}>
+            <span onClick={ () => setDisplayIndex(wIndex) }>
+              { wMove }
+            </span>
+            { '\xa0'.repeat(6 - wMove.length) }
+            {/* setting opacity to 1.0 offsets a cumulative reduction in opacity on each bIndex ply when displayIndex < this move's wIndex */}
+            <span onClick={ () => setDisplayIndex(bIndex) } style={{ opacity: (moveOpacity(wIndex) == 1.0) ? moveOpacity(bIndex) : 1.0 }}>
+              { displayMoves[wIndex + 1].san }
+            </span>
+          </li>
+        )
+      }
+    }
+
+    return components
+  }
+
   return (
-    <div className='game-panel-container col'>
+    <div className='game-panel-container col' style={{ display: ((displayGame !== null) ? 'flex' : ' none') }}>
       <div className="game-panel col">
-        <div id="opp-timer" className={'timer row' + (hasGame ? '' : ' invisible')}>
+        <div id="opp-timer" className={'timer row' + (hasGame ? '' : ' hidden')}>
           <p>00:00</p>
         </div>
-        <div id="opp-player" className={'player row' + (hasGame ? '' : ' invisible')}>
-          <p>~sampel-palnet</p>
+        <div id="opp-player" className={'player row' + (hasGame ? '' : ' hidden')}>
+          <p>{opponent}</p>
         </div>
-        <div className="moves col">
-          <div className="moves-divider"></div>
-          <p> 00  ply ply</p>
-          <p> 00  ply ply</p>
-          <p> 00  ply ply</p>
-          <p> 00  ply ply</p>
-          <p> 00  ply ply</p>
-          <p> 00  ply ply</p>
-          <p> 00  ply ply</p>
-          <p> 00  ply ply</p>
-          <p> 00  ply ply</p>
-          <p> 00  ply ply</p>
-          <p> 00  ply ply</p>
-          <p> 00  ply ply</p>
-          <p> 00  ply ply</p>
-          <p> 00  ply ply</p>
-          <p> 00  ply ply</p>
-          <p> 00  ply ply</p>
-          <p> 00  ply ply</p>
-          <p> 00  ply ply</p>
-          <p> 00  ply ply</p>
-          <p> 00  ply ply</p>
-          <p> 00  ply ply</p>
-          <p> 00  ply ply</p>
-          <p> 00  ply ply</p>
-          <p> 00  ply ply</p>
+        <div className={'moves col' + (hasGame ? '' : ' hidden')}>
+          <ol>
+            { moveList() }
+          </ol>
         </div>
-        <div id="our-player" className={'player row' + (hasGame ? '' : ' invisible')}>
-          <p>~sampel-palnet</p>
+        <div id="our-player" className={'player row' + (hasGame ? '' : ' hidden')}>
+          <p>~{window.ship}</p>
         </div>
-        <div id="our-timer" className={'timer row' + (hasGame ? '' : ' invisible')}>
+        <div id="our-timer" className={'timer row' + (hasGame ? '' : ' hidden')}>
           <p>00:00</p>
         </div>
         {/* buttons */}

--- a/src/frontend/tsx/Games.tsx
+++ b/src/frontend/tsx/Games.tsx
@@ -4,7 +4,7 @@ import useChessStore from '../ts/state/chessStore'
 import usePreferenceStore from '../ts/state/preferenceStore'
 
 export function Games () {
-  const { urbit, displayGame, activeGames, setDisplayGame } = useChessStore()
+  const { urbit, displayGame, activeGames, setDisplayGame, setDisplayIndex } = useChessStore()
   const { pieceTheme } = usePreferenceStore()
   const hasGame: boolean = (displayGame !== null)
 
@@ -32,7 +32,7 @@ export function Games () {
                 key={key}
                 className={`game active ${colorClass} ${status}`}
                 title={gameID}
-                onClick={() => setDisplayGame(activeGame)}>
+                onClick={() => { setDisplayGame(activeGame); setDisplayIndex(null) }}>
                 <div className='row'>
                   <piece className={`game-icon ${mySide} knight`}/>
                   <div className='col game-card'>

--- a/src/frontend/tsx/PracticePanel.tsx
+++ b/src/frontend/tsx/PracticePanel.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react'
+import { Chess, ChessInstance } from 'chess.js'
+import useChessStore from '../ts/state/chessStore'
+import { pokeAction, resign, offerDraw, claimSpecialDraw } from '../ts/helpers/urbitChess'
+import { CHESS } from '../ts/constants/chess'
+import { Side, GameID, SAN, GameInfo, ActiveGameInfo } from '../ts/types/urbitChess'
+
+export function PracticePanel () {
+  const { displayGame, setPracticeBoard } = useChessStore()
+  const hasGame: boolean = (displayGame !== null)
+  const practiceHasMoved = (localStorage.getItem('practiceBoard') !== CHESS.defaultFEN)
+  return (
+    <div className='game-panel-container col'>
+      <div className="game-panel col">
+        <button
+          className='option'
+          disabled={hasGame || !practiceHasMoved}
+          onClick={() => setPracticeBoard(null)}>
+          Reset Practice Board
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/urbit/lib/chess.hoon
+++ b/src/urbit/lib/chess.hoon
@@ -1335,13 +1335,15 @@
   |=  game=chess-game
   ^-  (list @t)
   %+  spun  moves.game
-  |=  [move=[chess-move chess-fen] position=chess-position]
+  |=  [move=[chess-move chess-fen chess-san] position=chess-position]
   ^-  [@t chess-position]
   :-  (~(algebraicize with-position position) -.move)
   (need (~(apply-move with-position position) -.move))
 ::
 ::  keep count of every move
 ::  add the move number to chess notation
+::  XX: should we remove this if we're not only not using
+::      it, but won't use it due to undo functionality?
 ++  algebraicize-and-number
   |=  game=chess-game
   ^-  (list @t)
@@ -1412,11 +1414,11 @@
       result=`%'0-1'
   :~
     ::  1. f3 e5
-     [[%move [%f %2] [%f %3] ~] 'rnbqkbnr/pppppppp/8/8/8/5P2/PPPPP1PP/RNBQKBNR b KQkq - 0 1']
-     [[%move [%e %7] [%e %5] ~] 'rnbqkbnr/pppp1ppp/8/4p3/8/5P2/PPPPP1PP/RNBQKBNR w KQkq e6 0 1']
+     [[%move [%f %2] [%f %3] ~] 'rnbqkbnr/pppppppp/8/8/8/5P2/PPPPP1PP/RNBQKBNR b KQkq - 0 1' 'f3']
+     [[%move [%e %7] [%e %5] ~] 'rnbqkbnr/pppp1ppp/8/4p3/8/5P2/PPPPP1PP/RNBQKBNR w KQkq e6 0 1' 'e5']
      ::  2. g4 Qh4#
-     [[%move [%g %2] [%g %4] ~] 'rnbqkbnr/pppp1ppp/8/4p3/6P1/5P2/PPPPP2P/RNBQKBNR b KQkq g3 0 1']
-     [[%move [%d %8] [%h %4] ~] 'rnb1kbnr/pppp1ppp/8/4p3/6Pq/5P2/PPPPP2P/RNBQKBNR w KQkq - 0 1']
+     [[%move [%g %2] [%g %4] ~] 'rnbqkbnr/pppp1ppp/8/4p3/6P1/5P2/PPPPP2P/RNBQKBNR b KQkq g3 0 1' 'g4']
+     [[%move [%d %8] [%h %4] ~] 'rnb1kbnr/pppp1ppp/8/4p3/6Pq/5P2/PPPPP2P/RNBQKBNR w KQkq - 0 1' 'Qh4#']
   ==
   ==
 --

--- a/src/urbit/mar/chess/game.hoon
+++ b/src/urbit/mar/chess/game.hoon
@@ -1,3 +1,4 @@
+/-  *chess
 /+  chess
 =,  format
 |_  game=chess-game:chess
@@ -9,15 +10,15 @@
   |%
   ++  noun  game
   ++  json
-    =+  game
     %-  pairs:enjs
-    :~  ['gameID' [%s (scot %da game-id)]]
-        ['event' [%s event]]
-        ['site' [%s site]]
-        ['round' [%s (round-string:chess round)]]
-        ['white' [%s (player-string:chess white)]]
-        ['black' [%s (player-string:chess black)]]
-        ['result' [%s ?~(result '' u.result)]]
+    :~  ['gameID' [%s (scot %da game-id.game)]]
+        ['event' [%s event.game]]
+        ['site' [%s site.game]]
+        ['round' [%s (round-string:chess round.game)]]
+        ['white' [%s (player-string:chess white.game)]]
+        ['black' [%s (player-string:chess black.game)]]
+        ['result' [%s ?~(result.game '' u.result.game)]]
+        ['moves' [%a ~]]
     ==
   --
 ++  grad  %noun

--- a/src/urbit/mar/chess/update.hoon
+++ b/src/urbit/mar/chess/update.hoon
@@ -45,7 +45,7 @@
         %-  pairs:enjs
         :~  ['chessUpdate' [%s 'position']]
             ['gameID' [%s (scot %da game-id.upd)]]
-            ['position' [%s position.upd]]
+            ['move' (pairs:enjs ~[['san' [%s san.upd]] ['fen' [%s position.upd]]])]
             ['specialDrawAvailable' [%b special-draw-available.upd]]
         ==
       %result

--- a/src/urbit/sur/chess.hoon
+++ b/src/urbit/sur/chess.hoon
@@ -172,6 +172,9 @@
 ::  chess-fen is a FEN position
 +$  chess-fen  @t
 ::
+::  chess-san is one move's SAN
++$  chess-san  @t
+::
 ::  chess-game stores metadata for a game
 ::  represented by chess-position
 +$  chess-game
@@ -211,8 +214,9 @@
     black=chess-player
   ::  %'0-1'
     result=(unit chess-result)
-  ::  a list of this round's moves and corresponding fen
-    moves=(list [chess-move chess-fen])
+  ::  a list of this round's moves, with
+  ::  corresponding fen and san for each move
+    moves=(list [chess-move chess-fen chess-san])
   ==
 ::
 ::  a challenge is the challenger's side,
@@ -253,7 +257,7 @@
       [%challenge-received who=ship challenge=chess-challenge]
       [%challenge-resolved who=ship]
       [%challenge-replied who=ship]
-      [%position game-id=@dau position=@t special-draw-available=?]
+      [%position game-id=@dau position=@t san=@t special-draw-available=?]
       [%draw-offer game-id=@dau]
       [%draw-declined game-id=@dau]
       [%undo-declined game-id=@dau]


### PR DESCRIPTION
@ashelkovnykov I'm just PR-ing this now to ask how you think I should update a game's move list upon receiving a new move. I've left two comments around line 60 in `chessStore.ts` where I think this should happen for an active game.

I'm not yet sure where I'm looking to update the practice board on a new move.

I've put the moves list in `%chess-game` on the backend and `GameInfo` on the frontend to account for archived games, which won't fall under `ActiveGameInfo`. But this creates some awkwardness in `receiveGame()` because I'm not getting new moves from the `%position` update itself. 

Sending a whole new list of moves in the `%position` update would require scrying `[%x %game @ta ~]` from `update.hoon`, which feels bad, and sending only the latest move would require:
* Some conditional logic on the frontend where the output of `algebraicize:with-position` (e.g. `'e4'`, `'d5'`) is appended to the array as `1. e4` or concatenated to get `1. e4 d5` depending on whether white or black moved.
* Amending the output of `algebraicize:with-position` from `'e4'` or `'d5'` to `'1. e4'` or `'1. e4 d5'`. That could comfortably be sent along with a `%position` update and appended to the `displayMoves` array without much complication. Alternatively I could write an arm `algebraicize-and-number:with-position` that does this. Either would let me append the move to the array in `receiveUpdate()` without much complication on the frontend. Considering you're thinking of splitting the frontend and backend, this is better than putting real game logic on the frontend. I've talked myself into this one in the process of writing it.

In either case, my second question is how to update `GameInfo` attributes from `receiveUpdate()`. The whole of `GameInfo` is updated in the line `info: currentGame.info`, but I couldn't do something like `info.moves = positionData.newMove`. I tried a whole `updateGameInfo` const that updated every attribute then changed that line to `info: updatedGameInfo`, but this crashed the whole frontend when I clicked on an active game. So maybe putting the moves list in `GameInfo` is just a bad idea, and I'll have to think of something else to account for both active and archived games.