### PR TITLE
Refactor the Challenges menu

### DIFF
--- a/src/frontend/ts/state/chessState.ts
+++ b/src/frontend/ts/state/chessState.ts
@@ -8,9 +8,11 @@ interface ChessState {
   activeGames: Map<GameID, ActiveGameInfo>
   incomingChallenges: Map<Ship, Challenge>
   outgoingChallenges: Map<Ship, Challenge>
+  friends: Array<Ship>
   setUrbit: (urbit: Urbit) => void
   setDisplayGame: (displayGame: ActiveGameInfo | null) => void
   setPracticeBoard: (practiceBoard: String | null) => void
+  setFriends: (friends: Array<Ship>) => void
   receiveChallengeUpdate: (data: ChallengeUpdate) => void
   receiveGame: (data: GameInfo) => void
   receiveUpdate: (data: ChessUpdate) => void

--- a/src/frontend/ts/state/chessStore.ts
+++ b/src/frontend/ts/state/chessStore.ts
@@ -2,6 +2,7 @@ import create from 'zustand'
 import Urbit from '@urbit/http-api'
 import { CHESS } from '../constants/chess'
 import { Update, Ship, GameID, GameInfo, ActiveGameInfo, Challenge, ChessUpdate, ChallengeUpdate, ChallengeSentUpdate, ChallengeReceivedUpdate, PositionUpdate, ResultUpdate, DrawOfferUpdate, DrawDeclinedUpdate, SpecialDrawPreferenceUpdate } from '../types/urbitChess'
+import { findFriends } from '../helpers/urbitChess'
 import ChessState from './chessState'
 
 const useChessStore = create<ChessState>((set, get) => ({
@@ -11,9 +12,11 @@ const useChessStore = create<ChessState>((set, get) => ({
   activeGames: new Map(),
   incomingChallenges: new Map(),
   outgoingChallenges: new Map(),
+  friends: [],
   setUrbit: (urbit: Urbit) => set({ urbit }),
   setDisplayGame: (displayGame: ActiveGameInfo | null) => set({ displayGame }),
   setPracticeBoard: (practiceBoard: String | null) => set({ practiceBoard }),
+  setFriends: async (friends: Array<Ship>) => set({ friends }),
   receiveChallengeUpdate: (data: ChallengeUpdate) => {
     switch (data.chessUpdate) {
       case Update.ChallengeSent: {

--- a/src/frontend/tsx/App.tsx
+++ b/src/frontend/tsx/App.tsx
@@ -3,12 +3,13 @@ import { Beforeunload } from 'react-beforeunload'
 import Urbit from '@urbit/http-api'
 import useChessStore from '../ts/state/chessStore'
 import { GameInfo, ChallengeUpdate } from '../ts/types/urbitChess'
+import { findFriends } from '../ts/helpers/urbitChess'
 import { Chessboard } from './Chessboard'
 import { Menu } from './Menu'
 import { GamePanel } from './GamePanel'
 
 export function App () {
-  const { urbit, setUrbit, receiveChallengeUpdate, receiveGame } = useChessStore()
+  const { urbit, setUrbit, receiveChallengeUpdate, receiveGame, setFriends } = useChessStore()
 
   //
   // Helper functions
@@ -32,6 +33,8 @@ export function App () {
       event: (data: GameInfo) => receiveGame(data),
       quit: () => {}
     })
+
+    setFriends(await findFriends('chess', '/friends'))
   }
 
   const teardown = () => {

--- a/src/frontend/tsx/Challenges.tsx
+++ b/src/frontend/tsx/Challenges.tsx
@@ -8,17 +8,18 @@ const selectedSideButtonClasses = 'side radio-selected'
 const unselectedSideButtonClasses = 'side radio-unselected'
 
 export function Challenges () {
+  // data
   const [who, setWho] = useState('')
   const [description, setDescription] = useState('')
   const [side, setSide] = useState(Side.Random)
+  const { urbit, incomingChallenges, outgoingChallenges, friends } = useChessStore()
+  // interface
   const [modalOpen, setModalOpen] = useState(false)
-  const [friends, setFriends] = useState([])
   const [challengingFriend, setChallengingFriend] = useState(false)
   const [showingFriends, setFriendsList] = useState(false)
-  const [showingIncoming, setIncoming] = useState(true)
-  const [showingOutgoing, setOutgoing] = useState(false)
+  const [showingIncoming, setIncomingList] = useState(true)
+  const [showingOutgoing, setOutgoingList] = useState(false)
   const [badChallengeAttempts, setBadChallengeAttempts] = useState(0)
-  const { urbit, incomingChallenges, outgoingChallenges } = useChessStore()
 
   const openModal = () => {
     setModalOpen(true)
@@ -77,18 +78,20 @@ export function Challenges () {
 
   const openFriends = async () => {
     setFriendsList(true)
-    setFriends(await findFriends('chess', '/friends'))
-    // XX: set showingIncoming and showingOutgoing to false
+    setIncomingList(false)
+    setOutgoingList(false)
   }
 
   const openIncoming = () => {
-    setIncoming(true)
-    setOutgoing(false)
+    setIncomingList(true)
+    setOutgoingList(false)
+    setFriendsList(false)
   }
 
   const openOutgoing = () => {
-    setOutgoing(true)
-    setIncoming(false)
+    setOutgoingList(true)
+    setIncomingList(false)
+    setFriendsList(false)
   }
 
   return (
@@ -97,7 +100,7 @@ export function Challenges () {
         <button className='option' onClick={openModal}>New Challenge</button>
         {/* XX: see how it looks replacing • with ☙ or ❧ or ❦ or 𐫱 */}
         <p>
-          <span onClick={openIncoming}>Incoming</span> ☙ <span onClick={openOutgoing}>Outgoing</span> ❧ <span onClick={openFriends}>Friends</span>
+          <span onClick={openIncoming} style={{ opacity: (showingIncoming ? 1.0 : 0.5) }}>Incoming</span> ☙ <span onClick={openOutgoing} style={{ opacity: (showingOutgoing ? 1.0 : 0.5) }}>Outgoing</span> ❧ <span onClick={openFriends} style={{ opacity: (showingFriends ? 1.0 : 0.5) }}>Friends</span>
         </p>
       </div>
       {/* incoming challenges list */}
@@ -164,6 +167,7 @@ export function Challenges () {
           })
         }
       </ul>
+      {/* friends list */}
       <ul id="friends" className='game-list' style={{ display: (showingFriends ? 'flex' : ' none') }}>
         {
           Array.from(friends).map((friend: Ship, key: number) => {


### PR DESCRIPTION
Connects the Incoming, Outgoing, and Friends lists into one coherent Challenges menu.

To fix a UI bug with the Friends list, it's been refactored to be a "first-class" piece of the app state along with the Incoming and Outgoing challenge lists. The `/friends` wire is now scried when the player first opens the app.