### PR TITLE
Fix syntax errors

### DIFF
--- a/src/urbit/app/chess.hoon
+++ b/src/urbit/app/chess.hoon
@@ -433,7 +433,6 @@
             games    (~(del by games) game-id.action)
             archive  (~(put by archive) game-id.action game.u.game-state(result `result))
           ==
-      ==
         %request-undo
           =/  game  (~(get by games) game-id.action)
           ?~  game

--- a/src/urbit/lib/chess.hoon
+++ b/src/urbit/lib/chess.hoon
@@ -416,7 +416,6 @@
   ^-  chess-position
   %+  rash
     fen
-  |.
   ;~  (glue ace)
       fen-to-board         ::  board
       fen-to-player        ::  player-to-move


### PR DESCRIPTION
2 syntax errors found their way into the master branch with all the big changes we merged yesterday