### PR TITLE
Amend errors from undo updates

### DIFF
--- a/src/urbit/mar/chess/update.hoon
+++ b/src/urbit/mar/chess/update.hoon
@@ -82,7 +82,7 @@
         ==
       %undo-accepted
         %-  pairs:enjs
-        :~  ['chessUpdate' [%s 'unco-accepted']]
+        :~  ['chessUpdate' [%s 'undo-accepted']]
             ['gameID' [%s (scot %da game-id.upd)]]
         ==
     ==

--- a/src/urbit/sur/chess.hoon
+++ b/src/urbit/sur/chess.hoon
@@ -258,6 +258,7 @@
       [%draw-declined game-id=@dau]
       [%undo-declined game-id=@dau]
       [%undo-accepted game-id=@dau]
+      [%undo-request game-id=@dau]
       [%result game-id=@dau result=chess-result]
       [%special-draw-preference game-id=@dau setting=?]
   ==


### PR DESCRIPTION
Adds %undo-request to the `chess-update` type and amends a typo in /mar/chess/update.