### PR TITLE
Fix last move highlighting to resolve #36

### DIFF
--- a/src/frontend/ts/state/chessStore.ts
+++ b/src/frontend/ts/state/chessStore.ts
@@ -65,8 +65,7 @@ const useChessStore = create<ChessState>((set, get) => ({
       autoClaimSpecialDraws: false,
       gotUndoRequest: false,
       sentUndoRequest: false,
-      info: data,
-      lastMove: null
+      info: data
     }
 
     set(state => ({ activeGames: state.activeGames.set(data.gameID, activeGame) }))
@@ -104,8 +103,7 @@ const useChessStore = create<ChessState>((set, get) => ({
             autoClaimSpecialDraws: currentGame.autoClaimSpecialDraws,
             gotUndoRequest: currentGame.gotUndoRequest,
             sentUndoRequest: currentGame.sentUndoRequest,
-            info: currentGame.info,
-            lastMove: positionData.lastMove
+            info: currentGame.info
           }
 
           set(state => ({ activeGames: state.activeGames.set(gameID, updatedGame) }))
@@ -150,8 +148,7 @@ const useChessStore = create<ChessState>((set, get) => ({
           autoClaimSpecialDraws: currentGame.autoClaimSpecialDraws,
           gotUndoRequest: currentGame.gotUndoRequest,
           sentUndoRequest: currentGame.sentUndoRequest,
-          info: currentGame.info,
-          lastMove: currentGame.lastMove
+          info: currentGame.info
         }
 
         set(state => ({ activeGames: state.activeGames.set(gameID, updatedGame) }))
@@ -174,8 +171,7 @@ const useChessStore = create<ChessState>((set, get) => ({
           autoClaimSpecialDraws: currentGame.autoClaimSpecialDraws,
           gotUndoRequest: currentGame.gotUndoRequest,
           sentUndoRequest: currentGame.sentUndoRequest,
-          info: currentGame.info,
-          lastMove: currentGame.lastMove
+          info: currentGame.info
         }
 
         set(state => ({ activeGames: state.activeGames.set(gameID, updatedGame) }))
@@ -198,8 +194,7 @@ const useChessStore = create<ChessState>((set, get) => ({
           autoClaimSpecialDraws: setting,
           gotUndoRequest: currentGame.gotUndoRequest,
           sentUndoRequest: currentGame.sentUndoRequest,
-          info: currentGame.info,
-          lastMove: currentGame.lastMove
+          info: currentGame.info
         }
 
         set(state => ({ activeGames: state.activeGames.set(gameID, updatedGame) }))
@@ -221,8 +216,7 @@ const useChessStore = create<ChessState>((set, get) => ({
           autoClaimSpecialDraws: currentGame.autoClaimSpecialDraws,
           gotUndoRequest: true,
           sentUndoRequest: currentGame.sentUndoRequest,
-          info: currentGame.info,
-          lastMove: currentGame.lastMove
+          info: currentGame.info
         }
 
         set(state => ({ activeGames: state.activeGames.set(gameID, updatedGame) }))
@@ -244,8 +238,7 @@ const useChessStore = create<ChessState>((set, get) => ({
           autoClaimSpecialDraws: currentGame.autoClaimSpecialDraws,
           gotUndoRequest: currentGame.gotUndoRequest,
           sentUndoRequest: false,
-          info: currentGame.info,
-          lastMove: currentGame.lastMove
+          info: currentGame.info
         }
 
         set(state => ({ activeGames: state.activeGames.set(gameID, updatedGame) }))
@@ -268,8 +261,7 @@ const useChessStore = create<ChessState>((set, get) => ({
           autoClaimSpecialDraws: currentGame.autoClaimSpecialDraws,
           gotUndoRequest: false,
           sentUndoRequest: false,
-          info: currentGame.info,
-          lastMove: currentGame.lastMove
+          info: currentGame.info
         }
 
         set(state => ({ activeGames: state.activeGames.set(gameID, updatedGame) }))

--- a/src/frontend/ts/state/chessStore.ts
+++ b/src/frontend/ts/state/chessStore.ts
@@ -65,7 +65,8 @@ const useChessStore = create<ChessState>((set, get) => ({
       autoClaimSpecialDraws: false,
       gotUndoRequest: false,
       sentUndoRequest: false,
-      info: data
+      info: data,
+      lastMove: null
     }
 
     set(state => ({ activeGames: state.activeGames.set(data.gameID, activeGame) }))
@@ -103,7 +104,8 @@ const useChessStore = create<ChessState>((set, get) => ({
             autoClaimSpecialDraws: currentGame.autoClaimSpecialDraws,
             gotUndoRequest: currentGame.gotUndoRequest,
             sentUndoRequest: currentGame.sentUndoRequest,
-            info: currentGame.info
+            info: currentGame.info,
+            lastMove: positionData.lastMove
           }
 
           set(state => ({ activeGames: state.activeGames.set(gameID, updatedGame) }))
@@ -148,7 +150,8 @@ const useChessStore = create<ChessState>((set, get) => ({
           autoClaimSpecialDraws: currentGame.autoClaimSpecialDraws,
           gotUndoRequest: currentGame.gotUndoRequest,
           sentUndoRequest: currentGame.sentUndoRequest,
-          info: currentGame.info
+          info: currentGame.info,
+          lastMove: currentGame.lastMove
         }
 
         set(state => ({ activeGames: state.activeGames.set(gameID, updatedGame) }))
@@ -171,7 +174,8 @@ const useChessStore = create<ChessState>((set, get) => ({
           autoClaimSpecialDraws: currentGame.autoClaimSpecialDraws,
           gotUndoRequest: currentGame.gotUndoRequest,
           sentUndoRequest: currentGame.sentUndoRequest,
-          info: currentGame.info
+          info: currentGame.info,
+          lastMove: currentGame.lastMove
         }
 
         set(state => ({ activeGames: state.activeGames.set(gameID, updatedGame) }))
@@ -194,7 +198,8 @@ const useChessStore = create<ChessState>((set, get) => ({
           autoClaimSpecialDraws: setting,
           gotUndoRequest: currentGame.gotUndoRequest,
           sentUndoRequest: currentGame.sentUndoRequest,
-          info: currentGame.info
+          info: currentGame.info,
+          lastMove: currentGame.lastMove
         }
 
         set(state => ({ activeGames: state.activeGames.set(gameID, updatedGame) }))
@@ -216,7 +221,8 @@ const useChessStore = create<ChessState>((set, get) => ({
           autoClaimSpecialDraws: currentGame.autoClaimSpecialDraws,
           gotUndoRequest: true,
           sentUndoRequest: currentGame.sentUndoRequest,
-          info: currentGame.info
+          info: currentGame.info,
+          lastMove: currentGame.lastMove
         }
 
         set(state => ({ activeGames: state.activeGames.set(gameID, updatedGame) }))
@@ -238,7 +244,8 @@ const useChessStore = create<ChessState>((set, get) => ({
           autoClaimSpecialDraws: currentGame.autoClaimSpecialDraws,
           gotUndoRequest: currentGame.gotUndoRequest,
           sentUndoRequest: false,
-          info: currentGame.info
+          info: currentGame.info,
+          lastMove: currentGame.lastMove
         }
 
         set(state => ({ activeGames: state.activeGames.set(gameID, updatedGame) }))
@@ -261,7 +268,8 @@ const useChessStore = create<ChessState>((set, get) => ({
           autoClaimSpecialDraws: currentGame.autoClaimSpecialDraws,
           gotUndoRequest: false,
           sentUndoRequest: false,
-          info: currentGame.info
+          info: currentGame.info,
+          lastMove: currentGame.lastMove
         }
 
         set(state => ({ activeGames: state.activeGames.set(gameID, updatedGame) }))

--- a/src/frontend/ts/types/chessground.ts
+++ b/src/frontend/ts/types/chessground.ts
@@ -1,6 +1,6 @@
-import * as cg from 'chessground/types'
+import { Key as CgKey } from 'chessground/types'
 
 export interface PromotionMove {
-  orig: cg.Key;
-  dest: cg.Key;
+  orig: CgKey;
+  dest: CgKey;
 }

--- a/src/frontend/ts/types/urbitChess.ts
+++ b/src/frontend/ts/types/urbitChess.ts
@@ -1,3 +1,5 @@
+import * as cg from 'chessground/types'
+
 //
 // Enumerations
 //
@@ -104,7 +106,7 @@ export type ActiveGameInfo = {
   gotUndoRequest: boolean,
   sentUndoRequest: boolean,
   info: GameInfo,
-  lastMove: Array<string>
+  lastMove: Array<cg.Key> | null
 }
 
 export type Challenge = {
@@ -151,7 +153,7 @@ export interface PositionUpdate extends ChessUpdate {
   position: FENPosition
   specialDrawAvailable: boolean
   move: Move | null
-  lastMove: Array<string>
+  lastMove: Array<cg.Key>
 }
 
 export interface ResultUpdate extends ChessUpdate {

--- a/src/frontend/ts/types/urbitChess.ts
+++ b/src/frontend/ts/types/urbitChess.ts
@@ -103,7 +103,8 @@ export type ActiveGameInfo = {
   autoClaimSpecialDraws: boolean,
   gotUndoRequest: boolean,
   sentUndoRequest: boolean,
-  info: GameInfo
+  info: GameInfo,
+  lastMove: Array<string>
 }
 
 export type Challenge = {
@@ -150,6 +151,7 @@ export interface PositionUpdate extends ChessUpdate {
   position: FENPosition
   specialDrawAvailable: boolean
   move: Move | null
+  lastMove: Array<string>
 }
 
 export interface ResultUpdate extends ChessUpdate {

--- a/src/frontend/ts/types/urbitChess.ts
+++ b/src/frontend/ts/types/urbitChess.ts
@@ -1,4 +1,4 @@
-import * as cg from 'chessground/types'
+import { Key as CgKey } from 'chessground/types'
 
 //
 // Enumerations
@@ -82,6 +82,8 @@ export type SAN = string
 export type FENPosition = string
 
 export type Move = {
+  start: CgKey
+  end: CgKey
   san: SAN
   fen: FENPosition
 }
@@ -105,8 +107,7 @@ export type ActiveGameInfo = {
   autoClaimSpecialDraws: boolean,
   gotUndoRequest: boolean,
   sentUndoRequest: boolean,
-  info: GameInfo,
-  lastMove: Array<cg.Key> | null
+  info: GameInfo
 }
 
 export type Challenge = {
@@ -153,7 +154,6 @@ export interface PositionUpdate extends ChessUpdate {
   position: FENPosition
   specialDrawAvailable: boolean
   move: Move | null
-  lastMove: Array<cg.Key>
 }
 
 export interface ResultUpdate extends ChessUpdate {

--- a/src/frontend/ts/types/urbitChess.ts
+++ b/src/frontend/ts/types/urbitChess.ts
@@ -82,8 +82,8 @@ export type SAN = string
 export type FENPosition = string
 
 export type Move = {
-  start: CgKey
-  end: CgKey
+  from: CgKey
+  to: CgKey
   san: SAN
   fen: FENPosition
 }

--- a/src/frontend/tsx/Chessboard.tsx
+++ b/src/frontend/tsx/Chessboard.tsx
@@ -196,6 +196,7 @@ export function Chessboard () {
       fen: (displayIndex == null || displayGame.info.moves == null)
         ? chess.fen()
         : displayGame.info.moves[displayIndex].fen,
+      lastMove: displayGame.lastMove as cg.Key[],
       viewOnly: isViewOnly,
       turnColor: sideToMove as cg.Color,
       check: chess.in_check(),

--- a/src/frontend/tsx/Chessboard.tsx
+++ b/src/frontend/tsx/Chessboard.tsx
@@ -89,10 +89,6 @@ export function Chessboard () {
 
     if (displayGame !== null) {
       chess.load(displayGame.position)
-      const config: CgConfig = {
-        lastMove: displayGame.lastMove
-      }
-      api?.set(config)
     } else if (practiceBoard !== null) {
       chess.load(practiceBoard)
     } else {
@@ -200,6 +196,12 @@ export function Chessboard () {
       fen: (displayIndex == null || displayGame.info.moves == null)
         ? chess.fen()
         : displayGame.info.moves[displayIndex].fen,
+      lastMove: (displayGame == null || displayGame.info.moves == null)
+        ? null
+        : [
+          displayGame.info.moves[displayIndex].from,
+          displayGame.info.moves[displayIndex].to
+        ],
       viewOnly: isViewOnly,
       turnColor: sideToMove as cg.Color,
       check: chess.in_check(),

--- a/src/frontend/tsx/Chessboard.tsx
+++ b/src/frontend/tsx/Chessboard.tsx
@@ -89,6 +89,10 @@ export function Chessboard () {
 
     if (displayGame !== null) {
       chess.load(displayGame.position)
+      const config: CgConfig = {
+        lastMove: displayGame.lastMove
+      }
+      api?.set(config)
     } else if (practiceBoard !== null) {
       chess.load(practiceBoard)
     } else {
@@ -196,7 +200,6 @@ export function Chessboard () {
       fen: (displayIndex == null || displayGame.info.moves == null)
         ? chess.fen()
         : displayGame.info.moves[displayIndex].fen,
-      lastMove: displayGame.lastMove as cg.Key[],
       viewOnly: isViewOnly,
       turnColor: sideToMove as cg.Color,
       check: chess.in_check(),

--- a/src/frontend/tsx/Chessboard.tsx
+++ b/src/frontend/tsx/Chessboard.tsx
@@ -191,7 +191,7 @@ export function Chessboard () {
       fen: (displayIndex == null || displayGame.info.moves == null)
         ? chess.fen()
         : displayGame.info.moves[displayIndex].fen,
-      lastMove: (displayGame == null || displayGame.info.moves == null)
+      lastMove: (displayGame == null || displayGame.info.moves == null || (displayGame.info.moves.length === 0))
         ? null
         : (displayIndex == null)
           ? [

--- a/src/frontend/tsx/Chessboard.tsx
+++ b/src/frontend/tsx/Chessboard.tsx
@@ -57,11 +57,6 @@ export function Chessboard () {
       ? Side.White
       : Side.Black
     : getCgColor(chess.turn()) as Side
-  const boardTitle = (displayGame !== null)
-    ? (orientation === Side.White)
-      ? `${CHESS.pieceWhiteKnight} ${displayGame.info.white} vs. ${CHESS.pieceBlackKnight} ${displayGame.info.black}`
-      : `${CHESS.pieceBlackKnight} ${displayGame.info.black} vs. ${CHESS.pieceWhiteKnight} ${displayGame.info.white}`
-    : `~${window.ship}'s practice board`
   const isViewOnly = (displayIndex == null)
     ? false
     : (displayGame.info.moves == null)
@@ -198,10 +193,15 @@ export function Chessboard () {
         : displayGame.info.moves[displayIndex].fen,
       lastMove: (displayGame == null || displayGame.info.moves == null)
         ? null
-        : [
-          displayGame.info.moves[displayIndex].from,
-          displayGame.info.moves[displayIndex].to
-        ],
+        : (displayIndex == null)
+          ? [
+            displayGame.info.moves[displayGame.info.moves.length - 1].from,
+            displayGame.info.moves[displayGame.info.moves.length - 1].to
+          ]
+          : [
+            displayGame.info.moves[displayIndex].from,
+            displayGame.info.moves[displayIndex].to
+          ],
       viewOnly: isViewOnly,
       turnColor: sideToMove as cg.Color,
       check: chess.in_check(),

--- a/src/urbit/app/chess.hoon
+++ b/src/urbit/app/chess.hoon
@@ -1125,13 +1125,13 @@
         (check-50-move-rule u.new-position)
     ==
   =/  special-draw-claim  &(special-draw-available auto-claim-special-draws.game-state)
-  ~&  (get-squares move)
+  ~&  (get-squares [move player-to-move.position.game-state])
   =/  position-update-card
     :*  %give
         %fact
         ~[/game/(scot %da game-id.game.game-state)/updates]
         %chess-update
-        !>([%position game-id.game.game-state (position-to-fen u.new-position) san special-draw-available (get-squares move)])
+        !>([%position game-id.game.game-state (position-to-fen u.new-position) san special-draw-available (get-squares [move player-to-move.position.game-state])])
     ==
   ::  check if game ends by checkmate, stalemate, or special draw
   ?:  ?|  in-checkmate
@@ -1203,7 +1203,7 @@
    ^-  ?
    (gte ply-50-move-rule.position 100)
 ++  get-squares
-  |=  move=chess-move
+  |=  [move=chess-move player=chess-side]
   ^-  [@t @t]
   ?-  -.move
     %move
@@ -1211,12 +1211,12 @@
     %castle
       ?-  +.move
         %queenside
-          ?-  player-to-move.position.game-state
+          ?-  player
             %white  ['e1' 'c1']
             %black  ['e8' 'c8']
           ==
         %kingside
-          ?-  player-to-move.position.game-state
+          ?-  player
             %white  ['e1' 'g1']
             %black  ['e8' 'g8']
           ==

--- a/src/urbit/app/chess.hoon
+++ b/src/urbit/app/chess.hoon
@@ -1125,12 +1125,13 @@
         (check-50-move-rule u.new-position)
     ==
   =/  special-draw-claim  &(special-draw-available auto-claim-special-draws.game-state)
+  ~&  (get-squares move)
   =/  position-update-card
     :*  %give
         %fact
         ~[/game/(scot %da game-id.game.game-state)/updates]
         %chess-update
-        !>([%position game-id.game.game-state (position-to-fen u.new-position) san special-draw-available])
+        !>([%position game-id.game.game-state (position-to-fen u.new-position) san special-draw-available (get-squares move)])
     ==
   ::  check if game ends by checkmate, stalemate, or special draw
   ?:  ?|  in-checkmate
@@ -1201,4 +1202,24 @@
    |=  position=chess-position
    ^-  ?
    (gte ply-50-move-rule.position 100)
+++  get-squares
+  |=  move=chess-move
+  ^-  [@t @t]
+  ?-  -.move
+    %move
+      [(cat 3 -.from.move (scot %ud +.from.move)) (cat 3 -.to.move (scot %ud +.to.move))]
+    %castle
+      ?-  +.move
+        %queenside
+          ?-  player-to-move.position.game-state
+            %white  ['e1' 'c1']
+            %black  ['e8' 'c8']
+          ==
+        %kingside
+          ?-  player-to-move.position.game-state
+            %white  ['e1' 'g1']
+            %black  ['e8' 'g8']
+          ==
+      ==
+  ==
 --

--- a/src/urbit/app/chess.hoon
+++ b/src/urbit/app/chess.hoon
@@ -811,12 +811,21 @@
       =/  game-state  (~(got by games) u.game-id)
       =/  fen  (position-to-fen position.game-state)
       =/  cards  ^-  (list card)
-         %+  turn
-           moves.game.game-state
-         |=  move=[move=chess-move fen=chess-fen san=chess-san]
-         :*  %give  %fact   ~[/game/(scot %da u.game-id)/updates]
-             %chess-update  !>([%position u.game-id fen.move san.move special-draw-available.game-state])
-         ==
+        %+  spun
+          moves.game.game-state
+        |=  [move=[move=chess-move fen=chess-fen san=chess-san] player=chess-side]
+        :-  :*  %give
+                %fact
+                ~[/game/(scot %da u.game-id)/updates]
+                %chess-update
+                !>  :*  %position
+                        u.game-id
+                        (get-squares move.move player)
+                        fen.move
+                        san.move
+                        special-draw-available.game-state
+            ==      ==
+            (opposite-side player)
       =?  cards  got-draw-offer.game-state
         :_  cards
         :*  %give  %fact  ~[/game/(scot %da u.game-id)/updates]
@@ -1125,14 +1134,18 @@
         (check-50-move-rule u.new-position)
     ==
   =/  special-draw-claim  &(special-draw-available auto-claim-special-draws.game-state)
-  ~&  (get-squares [move player-to-move.position.game-state])
   =/  position-update-card
-    :*  %give
-        %fact
-        ~[/game/(scot %da game-id.game.game-state)/updates]
-        %chess-update
-        !>([%position game-id.game.game-state (position-to-fen u.new-position) san special-draw-available (get-squares [move player-to-move.position.game-state])])
-    ==
+  :*  %give
+      %fact
+      ~[/game/(scot %da game-id.game.game-state)/updates]
+      %chess-update
+      !>  :*  %position
+              game-id.game.game-state
+              (get-squares move player-to-move.position.game-state)
+              (position-to-fen u.new-position)
+              san
+              special-draw-available
+  ==      ==
   ::  check if game ends by checkmate, stalemate, or special draw
   ?:  ?|  in-checkmate
           in-stalemate
@@ -1202,24 +1215,4 @@
    |=  position=chess-position
    ^-  ?
    (gte ply-50-move-rule.position 100)
-++  get-squares
-  |=  [move=chess-move player=chess-side]
-  ^-  [@t @t]
-  ?-  -.move
-    %move
-      [(cat 3 -.from.move (scot %ud +.from.move)) (cat 3 -.to.move (scot %ud +.to.move))]
-    %castle
-      ?-  +.move
-        %queenside
-          ?-  player
-            %white  ['e1' 'c1']
-            %black  ['e8' 'c8']
-          ==
-        %kingside
-          ?-  player
-            %white  ['e1' 'g1']
-            %black  ['e8' 'g8']
-          ==
-      ==
-  ==
 --

--- a/src/urbit/app/chess.hoon
+++ b/src/urbit/app/chess.hoon
@@ -1141,7 +1141,7 @@
       %chess-update
       !>  :*  %position
               game-id.game.game-state
-              (get-squares move player-to-move.position.game-state)
+              (get-squares move player-to-move.u.new-position)
               (position-to-fen u.new-position)
               san
               special-draw-available

--- a/src/urbit/lib/chess.hoon
+++ b/src/urbit/lib/chess.hoon
@@ -1425,4 +1425,30 @@
      [[%move [%d %8] [%h %4] ~] 'rnb1kbnr/pppp1ppp/8/4p3/6Pq/5P2/PPPPP2P/RNBQKBNR w KQkq - 0 1' 'Qh4#']
   ==
   ==
+::
+::  return the squares involved in a move
+++  get-squares
+  |=  [move=chess-move player=chess-side]
+  ::  XX: give this type a name
+  ^-  (pair @t @t)
+  ?-  -.move
+      %move
+    :-  (cat 3 -.from.move (scot %ud +.from.move))
+    (cat 3 -.to.move (scot %ud +.to.move))
+  ::
+      %castle
+    ?-  +.move
+        %queenside
+      ?-  player
+        %white  ['e1' 'c1']
+        %black  ['e8' 'c8']
+      ==
+    ::
+        %kingside
+      ?-  player
+        %white  ['e1' 'g1']
+        %black  ['e8' 'g8']
+      ==
+    ==
+  ==
 --

--- a/src/urbit/mar/chess/update.hoon
+++ b/src/urbit/mar/chess/update.hoon
@@ -45,9 +45,15 @@
         %-  pairs:enjs
         :~  ['chessUpdate' [%s 'position']]
             ['gameID' [%s (scot %da game-id.upd)]]
-            ['move' (pairs:enjs ~[['san' [%s san.upd]] ['fen' [%s position.upd]] ['lastMove' [%a ~[[%s -.last-move.upd] [%s +.last-move.upd]]]]])]
             ['specialDrawAvailable' [%b special-draw-available.upd]]
-        ==
+        ::
+            :-  'move'
+            %-  pairs:enjs
+            :~  ['from' [%s p.move.upd]]
+                ['to' [%s q.move.upd]]
+                ['san' [%s san.upd]]
+                ['fen' [%s position.upd]]
+        ==  ==
       %result
         %-  pairs:enjs
         :~  ['chessUpdate' [%s 'result']]

--- a/src/urbit/mar/chess/update.hoon
+++ b/src/urbit/mar/chess/update.hoon
@@ -45,7 +45,7 @@
         %-  pairs:enjs
         :~  ['chessUpdate' [%s 'position']]
             ['gameID' [%s (scot %da game-id.upd)]]
-            ['move' (pairs:enjs ~[['san' [%s san.upd]] ['fen' [%s position.upd]]])]
+            ['move' (pairs:enjs ~[['san' [%s san.upd]] ['fen' [%s position.upd]] ['lastMove' [%a ~[[%s -.last-move.upd] [%s +.last-move.upd]]]]])]
             ['specialDrawAvailable' [%b special-draw-available.upd]]
         ==
       %result

--- a/src/urbit/sur/chess.hoon
+++ b/src/urbit/sur/chess.hoon
@@ -257,7 +257,7 @@
       [%challenge-received who=ship challenge=chess-challenge]
       [%challenge-resolved who=ship]
       [%challenge-replied who=ship]
-      [%position game-id=@dau position=@t san=@t special-draw-available=?]
+      [%position game-id=@dau position=@t san=@t special-draw-available=? last-move=[@t @t]]
       [%draw-offer game-id=@dau]
       [%draw-declined game-id=@dau]
       [%undo-declined game-id=@dau]

--- a/src/urbit/sur/chess.hoon
+++ b/src/urbit/sur/chess.hoon
@@ -257,7 +257,6 @@
       [%challenge-received who=ship challenge=chess-challenge]
       [%challenge-resolved who=ship]
       [%challenge-replied who=ship]
-      [%position game-id=@dau position=@t san=@t special-draw-available=? last-move=[@t @t]]
       [%draw-offer game-id=@dau]
       [%draw-declined game-id=@dau]
       [%undo-declined game-id=@dau]
@@ -265,7 +264,14 @@
       [%undo-request game-id=@dau]
       [%result game-id=@dau result=chess-result]
       [%special-draw-preference game-id=@dau setting=?]
-  ==
+  ::
+      $:  %position
+          game-id=@dau
+          move=(pair @t @t)
+          position=@t
+          san=@t
+          special-draw-available=?
+  ==  ==
 ::
 ::  XX: document chess-rng
 ::


### PR DESCRIPTION
My thinking on this is that any kind of state involving the last move squares should come from the backend so that we don't have the potential of the frontend highlighting getting out of sync with the backend. 

Currently getting an error converting from chess-update to json, so it seems there's something wrong with how I've written the array conversion but I can't tell from the docs.