### PR TITLE
Update package.json and build.sh

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -136,7 +136,10 @@ echo "[%zuse $KELVIN]" > $DESK_DIR/sys.kelvin
 
 # Build frontend
 if [ $DOCKER -eq 1 ]; then
-  sudo docker build --tag ${DOCKER_IMAGE}:${VERSION_FULL} .
+  # Need to use legacy builder ( DOCKER_BUILDKIT=0) so that MacOS builds work until this issue is resolved:
+  #   https://github.com/moby/buildkit/issues/1271
+  # sudo docker build --tag ${DOCKER_IMAGE}:${VERSION_FULL} .
+  sudo DOCKER_BUILDKIT=0 docker build --tag ${DOCKER_IMAGE}:${VERSION_FULL} .
   sudo docker run --rm -v ${FRONTEND_DIR}:/app/output/ ${DOCKER_IMAGE}:${VERSION_FULL}
 
   # Copy additional src files for frontend

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbit-chess",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Chess app for Urbit",
   "keywords": [
     "chess",


### PR DESCRIPTION
- Missed the version in `package.json` when bumping to `0.9.3`
- Added `DOCKER_BUILDKIT` workaround to `build.sh` so that build works for MacOS users hitting [this issue](https://github.com/moby/buildkit/issues/1271)