### PR TITLE
Add -k option to build script

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -22,7 +22,7 @@ usage() {
   fi
 
   echo -e ""
-  echo -e "Usage:\t$SCRIPT_NAME [-h] [-n] [-s SHIP_NAME] [-u URL]"
+  echo -e "Usage:\t$SCRIPT_NAME [-h] [-n] [-s SHIP_NAME] [-u URL] [-k KELVIN]"
   echo -e ""
   echo -e "Build the app frontend and the desk files required to install it in Grid"
   echo -e ""
@@ -31,6 +31,7 @@ usage() {
   echo -e "  -n\tUse npm natively instead of through Docker"
   echo -e "  -s\tSet ship name to use (default: $DEFAULT_SHIP)"
   echo -e "  -u\tUse given URL to distribute glob over HTTP instead of over Ames"
+  echo -e "  -k\tSet kelvin version to build with"
   echo -e ""
   exit $1
 }
@@ -92,7 +93,7 @@ SHIP=$DEFAULT_SHIP
 # --------------------------------------
 
 # Parse arguments
-OPTS=":hs:u:n"
+OPTS=":hns:u:k:"
 while getopts ${OPTS} opt; do
   case ${opt} in
     h)
@@ -106,6 +107,9 @@ while getopts ${OPTS} opt; do
       ;;
     u)
       URL=$OPTARG
+      ;;
+    k)
+      KELVIN=$OPTARG
       ;;
     :)
       echo "$SCRIPT_NAME: Missing argument for '-${OPTARG}'" >&2


### PR DESCRIPTION
The %chess desk's kelvin version decreases regularly, but without regular maintenance our development fakeships lag behind. When we have a %chess kelvin lower than our fakeship's, we can either…
* Download the latest urbit binaries and build a new fakeship.
* Manually change the kelvin in `build.sh` and undo the change once we're ready to send in a PR.

Neither of these are ideal. To avoid this choice, this PR adds a `-k` option to the `build.sh` script that lets us specify the kelvin version we want to build with.

As far as I can tell most kelvin changes don't affect %chess functionality - manually changing the kelvin in `build.sh` has never caused an issue for me - so in almost all cases using this option is just a formality to make the compiler happy.