### PR TITLE
Add eslint to webpack workflow

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -22,13 +22,14 @@ usage() {
   fi
 
   echo -e ""
-  echo -e "Usage:\t$SCRIPT_NAME [-h] [-k KELVIN] [-n] [-s SHIP_NAME] [-u URL]"
+  echo -e "Usage:\t$SCRIPT_NAME [-h] [-k KELVIN] [-l] [-n] [-s SHIP_NAME] [-u URL]"
   echo -e ""
   echo -e "Build the app frontend and the desk files required to install it in Grid"
   echo -e ""
   echo -e "Options:"
   echo -e "  -h\tPrint script usage info"
   echo -e "  -k\tSet alternative kelvin version to use (default: $DEFAULT_KELVIN)"
+  echo -e "  -l\tFix formatting errors raised by eslint"
   echo -e "  -n\tUse npm natively instead of through Docker"
   echo -e "  -s\tSet ship name to use (default: $DEFAULT_SHIP)"
   echo -e "  -u\tUse given URL to distribute glob over HTTP instead of over Ames"
@@ -77,6 +78,7 @@ FRONTEND_DIR="$BUILD_DIR/frontend"
 
 DOCKER=1
 DOCKER_IMAGE="urbit-chess"
+LINT_FIX=0
 
 VERSION_MAJOR=0
 VERSION_MINOR=9
@@ -94,7 +96,7 @@ SHIP=$DEFAULT_SHIP
 # --------------------------------------
 
 # Parse arguments
-OPTS=":hns:u:k:"
+OPTS=":hns:u:k:l"
 while getopts ${OPTS} opt; do
   case ${opt} in
     h)
@@ -111,6 +113,9 @@ while getopts ${OPTS} opt; do
       ;;
     k)
       KELVIN=$OPTARG
+      ;;
+    l)
+      LINT_FIX=1
       ;;
     :)
       echo "$SCRIPT_NAME: Missing argument for '-${OPTARG}'" >&2
@@ -149,6 +154,10 @@ if [ $DOCKER -eq 1 ]; then
 
   # Copy additional src files for frontend
   sudo chown -R ${USER}:${USER} ${FRONTEND_DIR}
+elif [ $LINT_FIX -eq 0 ]; then
+  # Run linter, refuse to build if there are errors
+  (cd "$ROOT_DIR/src/frontend"; npm run lint; npm run build-no-docker)
 else
-  (cd "$ROOT_DIR/src/frontend"; npm run build-no-docker)
+  # Run linter, fix errors, then build
+  (cd "$ROOT_DIR/src/frontend"; npm run lint -- --fix; npm run build-no-docker)
 fi


### PR DESCRIPTION
The webpack workflow was supposed to free developers from the requirement to use Docker. In practice, this isn't tenable without worrying about whether the Docker workflow will be blocked by linter errors they didn't catch. They have to remember to run eslint natively, or test the build with Docker.

This PR adds eslint to the webpack workflow. By default, it copies the behaviour of the Docker workflow and refuses to build if there are errors.

This also adds an optional `-l` flag to fix errors automatically. Devs can skip hunting down and correcting dozens of lines of code, but no changes are made without their say-so.