### PR TITLE
marks: add missing .md mark

### DIFF
--- a/src/backend/dependencies/mar/md.hoon
+++ b/src/backend/dependencies/mar/md.hoon
@@ -1,0 +1,20 @@
+::
+::::  /hoon/md/mar
+  ::
+/?    310
+::
+=,  format
+=,  mimes:html
+|_  txt=wain
+::
+++  grab                                                ::  convert from
+  |%
+  ++  mime  |=((pair mite octs) (to-wain q.q))
+  ++  noun  wain                                        ::  clam from %noun
+  --
+++  grow
+  |%
+  ++  mime  [/text/plain (as-octs (of-wain txt))]
+  --
+++  grad  %mime
+--


### PR DESCRIPTION
Fixes error on fresh install when it encounters `README.md`